### PR TITLE
Do not use HTTPS for media.stv.no link

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -228,7 +228,7 @@
 
                     <div class="three columns">
                         <h5>
-                            <a href="https://media.stv.no/arkiv">
+                            <a href="http://media.stv.no/arkiv">
                                 Video&shy;arkivet</a>
                         </h5>
                         <p>


### PR DESCRIPTION
This is a temporary change, initiated because we have re-terminated
media.stv.no through samfundet-web1.smint.no, and haven't gotten
around to fixing certificate yet. In practice, this makes no
difference because the server redirected without regards to the scheme,
so you were redirected from https://media.stv.no/arkiv to
http://media.stv.no/arkiv/ anyway.