### PR TITLE
Remove highlight of Refusjonsskjema

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -132,7 +132,7 @@
                         </p>
                     </div>
                     <div class="four columns">
-                        <h5 class="new">
+                        <h5>
                             <a href="https://jira.smint.no/servicedesk/customer/portal/3/create/44">
                                 Refusjons&shy;skjema</a> <i class="fa fa-credit-card" aria-hidden="true"></i></h5>
                         <p>


### PR DESCRIPTION
Everyone has likely noticed it by now. We don't need it to stand out when the new volunteers are introduced to smint.no.