### PR TITLE
Update link to recordings & WP date

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -150,7 +150,7 @@
                     <div class="four columns comingsoon">
                         <h5>WordPress <i class="fa fa-wordpress" aria-hidden="true"></i></h5>
                         <p>
-                            <em>Kommer 2018!</em> Publiser og orga&shy;niser artikler på Under&shy;Dusken.no.
+                            <em>Kommer 20xx!</em> Publiser og orga&shy;niser artikler på Under&shy;Dusken.no.
                         </p>
                     </div>
 
@@ -204,7 +204,7 @@
 
                     <div class="four columns">
                         <h5>
-                            <a href="http://streamer.smint.no:8080/opptak/">
+                            <a href="http://streamer-tmp.smint.no:8080/opptak/">
                                 Opptak fra streamen</a>
                         </h5>
                         <p>
@@ -222,7 +222,7 @@
                     <div class="three columns comingsoon">
                         <h5>WordPress <i class="fa fa-wordpress" aria-hidden="true"></i></h5>
                         <p>
-                            <em>Kommer 2018!</em> Publiser og orga&shy;niser video på Under&shy;Dusken.no.
+                            <em>Kommer 20xx!</em> Publiser og orga&shy;niser video på Under&shy;Dusken.no.
                         </p>
                     </div>
 


### PR DESCRIPTION
- Recordings are stored on temporary streamer, existing recordings will be transferred once old streamer is not used
- Port change in WP date made by @emilhf on deployed version into repository