### PR TITLE
Remove link to FTP slots, link to sysadmin@

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -98,22 +98,12 @@
                             Se status og betal inn til spleise&shy;laget.
                         </p>
                     </div>
-
-
-                    <!--                                <div class="four columns comingsoon">
-                                                <h5>
-                                                        Info&shy;skjerm <i class="fa fa-television"></i>
-                                                </h5>
-                                                <p>
-                                                    <em>Kommer 2018!</em> Foreslå innhold til publikums&shy;skjermen på Lucas.
-                                                </p>
-                                            </div> -->
                 </div>
 
                 <div class="row">
                     <div class="four columns">
                         <h5>
-                            <a href="mailto:sysadmin@studentmediene.no">
+                            <a href="mailto:sysadmin@studentmediene.no&subject=Glemt%20passord&body=Hei%21%20Jeg%20har%20glemt%20passordet%20til%20brukeren%20min%2C%20BRUKERNAVNET%20DITT%20HER.%20Kan%20dere%20hjelpe%20meg%3F">
                                 Glemt passord</a> <i class="fa fa-key" aria-hidden="true"></i>
                         </h5>
                         <p>

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -113,12 +113,11 @@
                 <div class="row">
                     <div class="four columns">
                         <h5>
-                            <a href="http://bruker.smint.no/">
+                            <a href="mailto:sysadmin@studentmediene.no">
                                 Glemt passord</a> <i class="fa fa-key" aria-hidden="true"></i>
                         </h5>
                         <p>
-                            Endre passord på SM-brukeren din. Har du ikke tilgang til epost, kontakt
-                            <a href="mailto:sysadmin@studentmediene.no">sysadmin@studentmediene.no</a>.
+                            Systemadministrasjonen kan gi deg et midlertidig passord, kontakt <a href="mailto:sysadmin@studentmediene.no">sysadmin@studentmediene.no</a>.
                         </p>
                     </div>
                     <div class="four columns">

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -229,14 +229,14 @@
                 <h4>Video&nbsp;&nbsp;<i class="fa fa-video-camera" aria-hidden="true"></i></h4>
 
                 <div class="row">
-                    <div class="three columns comingsoon">
+                    <div class="four columns comingsoon">
                         <h5>WordPress <i class="fa fa-wordpress" aria-hidden="true"></i></h5>
                         <p>
                             <em>Kommer 20xx!</em> Publiser og orga&shy;niser video på Under&shy;Dusken.no.
                         </p>
                     </div>
 
-                    <div class="three columns">
+                    <div class="four columns">
                         <h5>
                             <a href="http://media.stv.no/arkiv">
                                 Video&shy;arkivet</a>
@@ -245,16 +245,7 @@
                             Forevige videoer i vårt video&shy;arkiv, som også gjør dem klar for web.
                         </p>
                     </div>
-                    <div class="three columns">
-                        <h5>
-                            <a href="https://ftpslots.smint.no/">
-                                Fil&shy;overføring</a>
-                        </h5>
-                        <p>
-                            Last opp filer og del dem med andre.
-                        </p>
-                    </div>
-                    <div class="three columns">
+                    <div class="four columns">
                         <h5>
                             <a href="https://dusken.no/admin">
                                 Chimera</a>


### PR DESCRIPTION
FTPslots is dead and not used, so don't link to it.

The link to the "forgotten password" service does not do the task of helping users who forgot their password, it's only usable by those who wish to _change_ their (remembered) password. Instead, ask users to send an email to the right division, with guidance on how to formulate such an email.