### PR TITLE
Remove WordPress "coming soon"

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -136,24 +136,7 @@
             <div class="main-links">
                 <h4>Skrivende&nbsp;&nbsp;<i class="fa fa-pencil" aria-hidden="true"></i></h4>
                 <div class="row">
-                    <div class="four columns comingsoon">
-                        <h5>WordPress <i class="fa fa-wordpress" aria-hidden="true"></i></h5>
-                        <p>
-                            <em>Kommer 20xx!</em> Publiser og orga&shy;niser artikler på Under&shy;Dusken.no.
-                        </p>
-                    </div>
-
-                    <div class="four columns">
-                        <h5>
-                            <a href="https://momus.smint.no">
-                                Momus</a>
-                            <i class="fa fa-newspaper-o" aria-hidden="true"></i>
-                        </h5>
-                        <p>
-                            Skriv og organiser artikler for Under&nbsp;Duskens papir&shy;avis.
-                        </p>
-                    </div>
-                    <div class="four columns">
+                    <div class="six columns">
                         <h5>
                             <a href="https://dusken.no/admin">
                                 Chimera</a>
@@ -161,6 +144,16 @@
                         </h5>
                         <p>
                             Publiser og orga&shy;niser arti&shy;kler på Dusken.no.
+                        </p>
+                    </div>
+                    <div class="six columns">
+                        <h5>
+                            <a href="https://momus.smint.no">
+                                Momus</a>
+                            <i class="fa fa-newspaper-o" aria-hidden="true"></i>
+                        </h5>
+                        <p>
+                            Skriv og organiser artikler for Under&nbsp;Duskens papir&shy;avis.
                         </p>
                     </div>
                 </div>
@@ -219,23 +212,7 @@
                 <h4>Video&nbsp;&nbsp;<i class="fa fa-video-camera" aria-hidden="true"></i></h4>
 
                 <div class="row">
-                    <div class="four columns comingsoon">
-                        <h5>WordPress <i class="fa fa-wordpress" aria-hidden="true"></i></h5>
-                        <p>
-                            <em>Kommer 20xx!</em> Publiser og orga&shy;niser video på Under&shy;Dusken.no.
-                        </p>
-                    </div>
-
-                    <div class="four columns">
-                        <h5>
-                            <a href="http://media.stv.no/arkiv">
-                                Video&shy;arkivet</a>
-                        </h5>
-                        <p>
-                            Forevige videoer i vårt video&shy;arkiv, som også gjør dem klar for web.
-                        </p>
-                    </div>
-                    <div class="four columns">
+                    <div class="six columns">
                         <h5>
                             <a href="https://dusken.no/admin">
                                 Chimera</a>
@@ -243,6 +220,15 @@
                         </h5>
                         <p>
                             Publiser og orga&shy;niser video på Dusken.no.
+                        </p>
+                    </div>
+                    <div class="six columns">
+                        <h5>
+                            <a href="http://media.stv.no/arkiv">
+                                Video&shy;arkivet</a>
+                        </h5>
+                        <p>
+                            Forevige videoer i vårt video&shy;arkiv, som også gjør dem klar for web.
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
The new replacement for Chimera may not be WordPress after all. Plus, it doesn't need to be advertised long before release.

With one less entry for writers and video producers, the grid looked a bit weird with 3 columns for writers and video producers and 4 columns for on-air talents. So all three groups use 4 columns now, with the entries for writers and video producers taking up two such columns.

You can look at the result here: http://folk.ntnu.no/twdahl/smint.no/webroot/